### PR TITLE
fix: remove debug console.log from popup.js

### DIFF
--- a/addon/js/popup.js
+++ b/addon/js/popup.js
@@ -17,8 +17,7 @@ function ajax(conf) {
 	var xhr = new XMLHttpRequest();
 	xhr.open("GET", conf.url, true);
 	xhr.onreadystatechange = function() {
-		console.log('xhr',xhr);
-		if (xhr && xhr.readyState == 4 && xhr.status == 200) {
+				if (xhr && xhr.readyState == 4 && xhr.status == 200) {
 			var data=JSON.parse(xhr.response);
 			conf.success(data);
 		}


### PR DESCRIPTION
Removed a leftover debug console.log statement that was logging XMLHttpRequest objects to the browser console in production code. This reduces noise in the browser console and avoids potential information exposure.